### PR TITLE
Various bugfixes

### DIFF
--- a/plugin/c2runtime/runtime.js
+++ b/plugin/c2runtime/runtime.js
@@ -86,6 +86,8 @@ cr.plugins_.Colyseus = function(runtime)
      return (this.lastType === type);
    };
    Cnds.prototype.OnRoomListen = function (path, operation) {
+     var operationList = ['any', 'add', 'replace', 'remove'];
+     operation = operationList[operation];
      var self = this;
      var change = this.lastChange;
 

--- a/plugin/c2runtime/runtime.js
+++ b/plugin/c2runtime/runtime.js
@@ -237,9 +237,14 @@ cr.plugins_.Colyseus = function(runtime)
      var value = container;
 
      // deeply get the requested variable from the room's state.
-     do {
-       value = value[path.shift()];
-     } while (path.length > 0);
+     try {
+       do {
+         value = value[path.shift()];
+       } while (path.length > 0);
+     } catch (e) {
+       console.warn(e);
+       return null;
+     }
 
      return value;
    }

--- a/plugin/c2runtime/runtime.js
+++ b/plugin/c2runtime/runtime.js
@@ -100,7 +100,7 @@ cr.plugins_.Colyseus = function(runtime)
        rules = rules.map(function(segment) {
          // replace placeholder matchers
          return (segment.indexOf(":") === 0)
-           ? self.room.matcherPlaceholders[segment] || this.matcherPlaceholders[":*"]
+           ? self.room.matcherPlaceholders[segment] || self.room.matcherPlaceholders[":*"]
            : new RegExp("^" + segment + "$");
        });
        this.listeners[path] = rules;

--- a/plugin/c2runtime/runtime.js
+++ b/plugin/c2runtime/runtime.js
@@ -213,7 +213,7 @@ cr.plugins_.Colyseus = function(runtime)
 
    Exps.prototype.State = function (ret, variablePath)
    {
-     ret.set_any(getDeepVariable(variablePath, this.room.data));
+     ret.set_any(getDeepVariable(variablePath, this.room.state));
    };
 
    Exps.prototype.Path = function (ret, variable) {


### PR DESCRIPTION
Hi there,
This PR fixes a few bugs I found with this plugin.

* onListen was ignoring all signals, because the `operation` parameter returned the index of the dropdown instead of the value. Maybe is it some kind of breaking change in the editor?
* The onListen feature crashes when using a parameter != :id, because `this.matcherPlaceholders[":*"]` was not defined. I assumed it was meant to be `self.room.matcherPlaceholders[":*"]`
* `Colyseus.State()` always crashed, because it was accessing to `this.room.data` instead of `this.room.state`
* I've added a `try {...} catch {...}` to the `getDeepVariable` helper function, to handle wrong paths gracefully.

I hope you'll appreciate ;)

_As a side note: The build command `c3addon pack --root plugin` is kinda broken. It generates a package that is recognized as invalid from Construct. To make it work, I had to unzip it and zip it again the files to create a valid one._
